### PR TITLE
Add instructions on how to install ytcfilter beta

### DIFF
--- a/src/lib/translations/en/common.json
+++ b/src/lib/translations/en/common.json
@@ -11,5 +11,9 @@
   "about_us": "About Us",
   "contact": "Contact",
   "donations": "Donations",
-  "privacy_policy": "Privacy Policy"
+  "privacy_policy": "Privacy Policy",
+  "install.license": "This software is available under a <a href=\"https://choosealicense.com/licenses/agpl-3.0/\" class=\"link link-secondary\">AGPL-3.0</a> license.",
+  "install.source_code": "Source code is available on <a href=\"https://github.com/LiveTL/LiveTL\" class=\"link link-secondary\">Github</a>.",
+  "install.chrome": "Download for Chrome",
+  "install.firefox": "Download for Firefox"
 }

--- a/src/lib/translations/en/ytcfilter.json
+++ b/src/lib/translations/en/ytcfilter.json
@@ -1,5 +1,5 @@
 {
-  "subtitle": "The most powerful and intuitive YouTube chat filter extension ever.",
+  "subtitle": "The most powerful and intuitive YouTube chat filter extension.",
   "cat_btn": "Join Beta",
   "install.title": "Install YtcFilter",
   "install.beta": "Download on Github"

--- a/src/lib/translations/en/ytcfilter.json
+++ b/src/lib/translations/en/ytcfilter.json
@@ -1,4 +1,6 @@
 {
   "subtitle": "The most powerful and intuitive YouTube chat filter extension ever.",
-  "cat_btn": "Join Beta"
+  "cat_btn": "Join Beta",
+  "install.title": "Install YtcFilter",
+  "install.beta": "Download on Github"
 }

--- a/src/lib/translations/ja/common.json
+++ b/src/lib/translations/ja/common.json
@@ -11,5 +11,9 @@
   "about_us": "開発チームについて",
   "contact": "連絡先",
   "donations": "ドネーション",
-  "privacy_policy": "プライバシー・ポリシー"
+  "privacy_policy": "プライバシー・ポリシー",
+  "install.license": "このソフトウェアは<a href=\"https://choosealicense.com/licenses/agpl-3.0/\" class=\"link link-secondary\">AGPL-3.0</a>ライセンスの下提供されています。",
+  "install.source_code": "ソースコードは<a href=\"https://github.com/LiveTL/LiveTL\" class=\"link link-secondary\">Github</a>にて開示しています。",
+  "install.chrome": "Chrome 用ダウンロード",
+  "install.firefox": "Firefox 用ダウンロード"
 }

--- a/src/lib/translations/ja/ytcfilter.json
+++ b/src/lib/translations/ja/ytcfilter.json
@@ -1,4 +1,6 @@
 {
   "subtitle": "かつてないほど機能的な YouTube チャットフィルター。",
-  "cat_btn": "Beta に参加"
+  "cat_btn": "Beta に参加",
+  "install.title": "LiveTLをインストール",
+  "install.beta": "Githubでダウンロード"
 }

--- a/src/routes/ytcfilter/+page.svelte
+++ b/src/routes/ytcfilter/+page.svelte
@@ -2,18 +2,14 @@
   import { t } from '$lib/translation';
 </script>
 
-<div class="hero min-h-screen">
+<section class="hero min-h-screen">
   <div class="hero-content text-center">
     <div class="max-w-md">
       <h1 class="text-5xl font-bold text-slate-900">YtcFilter</h1>
       <p class="py-6 text-slate-800">
         {$t('ytcfilter.subtitle')}
       </p>
-      <a
-        class="btn btn-secondary rounded-xl text-base-100"
-        href="https://github.com/LiveTL/ytcfilter/releases/latest"
-        >{$t('ytcfilter.cat_btn')}</a
-      >
+      <a class="btn btn-primary rounded-xl text-base-100" href="/ytcfilter/install">{$t('common.install')}</a>
     </div>
   </div>
-</div>
+</section>

--- a/src/routes/ytcfilter/install/+page.svelte
+++ b/src/routes/ytcfilter/install/+page.svelte
@@ -38,13 +38,13 @@
     </h1>
 
     <section class="flex flex-col gap-y-8" id="download-links-release">
-      <div class="space-y-4">
+      <div class="flex flex-col items-center justify-center space-y-4">
         <h2 class="text-center text-2xl">YtcFilter v2</h2>
         <a
           href={downloadLinks['v2']['chrome']}
           target="_blank"
           rel="noopener noreferrer"
-          class="btn btn-primary mr-4 rounded-full text-base-100"
+          class="btn btn-primary rounded-full text-base-100"
         >
           <Icon
             src={Googlechrome}

--- a/src/routes/ytcfilter/install/+page.svelte
+++ b/src/routes/ytcfilter/install/+page.svelte
@@ -39,7 +39,7 @@
 
     <section class="flex flex-col gap-y-8" id="download-links-release">
       <div class="space-y-4">
-        <h2 class="text-center text-2xl">v2</h2>
+        <h2 class="text-center text-2xl">YtcFilter v2</h2>
         <a
           href={downloadLinks['v2']['chrome']}
           target="_blank"
@@ -69,7 +69,7 @@
       </div>
 
       <div class="flex flex-col justify-center space-y-4">
-        <h2 class="text-center text-2xl">beta</h2>
+        <h2 class="text-center text-2xl">YtcFilter v3 Beta</h2>
         <a
           href={downloadLinks['v3']['beta']}
           target="_blank"

--- a/src/routes/ytcfilter/install/+page.svelte
+++ b/src/routes/ytcfilter/install/+page.svelte
@@ -1,0 +1,96 @@
+<script lang="ts">
+  import YtcFilterLogo from '$lib/assets/ytcfilter/logo-small.png';
+
+  import { t } from '$lib/translation';
+
+  import { Icon } from '@steeze-ui/svelte-icon';
+  import {
+    Googlechrome,
+    Firefoxbrowser,
+    Github,
+  } from '@steeze-ui/simple-icons';
+
+  const downloadLinks = {
+    v2: {
+      chrome:
+        'https://chromewebstore.google.com/detail/ytcfilter/mnldnbhgfocmkehnlkeanlhfmopepnko',
+      firefox: 'https://addons.mozilla.org/en-US/firefox/addon/ytcfilter/',
+    },
+    v3: {
+      beta: 'https://github.com/LiveTL/ytcfilter/releases/latest',
+    },
+  };
+</script>
+
+<section class="container mx-auto">
+  <div
+    class="mx-auto flex h-screen max-w-3xl flex-col items-center justify-center space-y-8"
+    id="install"
+  >
+    <img
+      src={YtcFilterLogo}
+      alt="YtcFilter Logo"
+      class="mx-auto w-48 rounded-2xl shadow-2xl shadow-info"
+    />
+
+    <h1 class="mb-4 text-center text-4xl font-bold">
+      {@html $t('ytcfilter.install.title')}
+    </h1>
+
+    <section class="flex flex-col gap-y-8" id="download-links-release">
+      <div class="space-y-4">
+        <h2 class="text-center text-2xl">v2</h2>
+        <a
+          href={downloadLinks['v2']['chrome']}
+          target="_blank"
+          rel="noopener noreferrer"
+          class="btn btn-primary mr-4 rounded-full text-base-100"
+        >
+          <Icon
+            src={Googlechrome}
+            theme="solid"
+            size="18"
+            class="mr-2 justify-end"
+          />
+          {$t('common.install.chrome')}</a
+        >
+        <a
+          href={downloadLinks['v2']['firefox']}
+          target="_blank"
+          rel="noopener noreferrer"
+          class="btn btn-secondary rounded-full text-base-100"
+          ><Icon
+            src={Firefoxbrowser}
+            theme="solid"
+            size="18"
+            class="mr-2 justify-end"
+          />{$t('common.install.firefox')}</a
+        >
+      </div>
+
+      <div class="flex flex-col justify-center space-y-4">
+        <h2 class="text-center text-2xl">beta</h2>
+        <a
+          href={downloadLinks['v3']['beta']}
+          target="_blank"
+          rel="noopener noreferrer"
+          class="btn-neutral btn mx-auto rounded-full text-base-100"
+          ><Icon
+            src={Github}
+            theme="solid"
+            size="18"
+            class="mr-2 justify-end"
+          />{$t('ytcfilter.install.beta')}</a
+        >
+      </div>
+    </section>
+
+    <section
+      class="mx-auto space-y-2 text-center text-base"
+      id="license-source"
+    >
+      <p>{@html $t('common.install.license')}</p>
+      <p>{@html $t('common.install.source_code')}</p>
+    </section>
+  </div>
+</section>


### PR DESCRIPTION
Fixes #2

Add a separate YtcFilter install page, with links to both the old and new v3 version beta.